### PR TITLE
Feature/simplify node

### DIFF
--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -44,8 +44,6 @@ use serde_with::{DisplayFromStr, serde_as};
 use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock, Weak};
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering;
 
 use crate::filter::BitsProperty;
 use crate::maps::EventMap;
@@ -82,7 +80,6 @@ pub struct LedgerNode<T, M> {
     event:       T,
     next_seq_no: OnceCell<u32>,
     children:    RwLock<M>,
-    cnt:         AtomicU32,
 }
 
 // WARN: We decide to implement Send + Sync here for LedgerNode,
@@ -104,7 +101,6 @@ where
             event:       T::default(),
             parent:      None,
             children:    RwLock::new(M::new()),
-            cnt:         AtomicU32::new(0),
         })
     }
 
@@ -117,17 +113,16 @@ where
             event,
             parent: Some(Arc::downgrade(parent)),
             children: RwLock::new(M::new()),
-            cnt: AtomicU32::new(0),
         })
     }
 
+    #[must_use]
     pub fn new_children(&self, event: T) -> Arc<Self> {
         let new_node = Self::from_parent(&self.me.upgrade().unwrap(), event.clone());
         self.children
             .write()
             .unwrap()
-            .insert(event, new_node.clone());
-        new_node.clone()
+            .insert(event, new_node)
     }
 
     pub fn children(&self) -> Vec<Arc<Self>> {
@@ -161,25 +156,13 @@ where
             .map(|&seq_no| Uid::new(seq_no, self.event.clone().into()))
     }
 
+    #[must_use]
     pub fn insert(&self, event: impl Into<T>) -> Arc<Self> {
         let raw_event = event.into();
-        let mut cnt = self.cnt.load(Ordering::Relaxed);
-        loop {
-            if let Some(next) = self.children.read().unwrap().get(&raw_event) {
-                return next.clone();
-            } else {
-                let mut writer = self.children.write().unwrap();
-                match self.cnt.compare_exchange(cnt, cnt + 1, Ordering::Acquire, Ordering::Relaxed) {
-                    Ok(_) => {
-                        // Successfully reserved the next sequence number, now insert the new node
-                        let new_node =
-                            LedgerNode::from_parent(&self.me.upgrade().unwrap(), raw_event.clone());
-                        writer.insert(raw_event, new_node.clone());
-                        return new_node;
-                    }
-                    Err(e) => cnt = e,
-                }
-            }
+        if let Some(next) = self.children.read().unwrap().get(&raw_event) {
+            next.clone()
+        } else {
+            self.new_children(raw_event)
         }
     }
 
@@ -301,7 +284,6 @@ where
                 event: node.event.clone(),
                 next_seq_no: node.next_seq_no.clone(),
                 children: RwLock::new(M::new()),
-                cnt: AtomicU32::new(node.cnt.load(Ordering::Relaxed)),
             });
 
             let children = node.children.read().unwrap();

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -118,11 +118,13 @@ where
 
     #[must_use]
     pub fn new_children(&self, event: T) -> Arc<Self> {
-        let new_node = Self::from_parent(&self.me.upgrade().unwrap(), event.clone());
         self.children
             .write()
             .unwrap()
-            .insert(event, new_node)
+            .insert_with(
+                event.clone(),
+                || Self::from_parent(&self.me.upgrade().unwrap(), event.clone())
+            )
     }
 
     pub fn children(&self) -> Vec<Arc<Self>> {

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -15,7 +15,11 @@ pub trait EventMap<K, V> {
     fn new() -> Self;
     fn get(&self, querry: &K) -> Option<&V>;
     fn values(&self) -> Self::Values<'_>;
-    fn insert(&mut self, k: K, v: V) -> Option<V>;
+
+    /// Don't override existent entry,
+    /// but return its values instead of the one wanted to insert
+    fn insert(&mut self, k: K, v: V) -> V;
+
     fn remove(&mut self, querry: &K) -> Option<V>;
     fn clear(&mut self);
     fn is_empty(&self) -> bool;
@@ -60,15 +64,14 @@ impl<K: RawEvent, const N: usize> EventMap<K, Arc<LedgerNode<K, SmallMap<K, N>>>
         self.items.iter().map(|(_k, v)| v)
     }
 
-    fn insert(&mut self, k: K, v: Self::Item) -> Option<Self::Item> {
+    fn insert(&mut self, k: K, v: Self::Item) -> Self::Item {
         match self.items.binary_search_by(|(key, _)| key.cmp(&k)) {
             Ok(idx) => {
-                let old = std::mem::replace(&mut self.items[idx].1, v); // replace existing
-                Some(old)
+                self.items[idx].1.clone()
             }
             Err(idx) => {
-                self.items.insert(idx, (k, v)); // keep sorted
-                None
+                self.items.insert(idx, (k, v.clone())); // keep sorted
+                v
             }
         }
     }
@@ -100,6 +103,7 @@ impl<K: RawEvent> EventMap<K, Arc<LedgerNode<K, EventHashMap<K>>>> for EventHash
     where
         K: 'a;
 
+    // TODO: Investigate if `with_capacity` improves performance for HashMap use vs SmallMap
     fn new() -> Self {
         Self {
             items: std::collections::HashMap::new(),
@@ -111,8 +115,8 @@ impl<K: RawEvent> EventMap<K, Arc<LedgerNode<K, EventHashMap<K>>>> for EventHash
     fn values(&self) -> Self::Values<'_> {
         self.items.values()
     }
-    fn insert(&mut self, k: K, v: Self::Item) -> Option<Self::Item> {
-        self.items.insert(k, v)
+    fn insert(&mut self, k: K, v: Self::Item) -> Self::Item {
+        self.items.entry(k).or_insert(v).clone()
     }
     fn remove(&mut self, query: &K) -> Option<Self::Item> {
         self.items.remove(query)
@@ -148,8 +152,8 @@ impl<K: RawEvent> EventMap<K, Arc<LedgerNode<K, EventBTreeMap<K>>>> for EventBTr
     fn values(&self) -> Self::Values<'_> {
         self.items.values()
     }
-    fn insert(&mut self, k: K, v: Self::Item) -> Option<Self::Item> {
-        self.items.insert(k, v)
+    fn insert(&mut self, k: K, v: Self::Item) -> Self::Item {
+        self.items.entry(k).or_insert(v).clone()
     }
     fn remove(&mut self, query: &K) -> Option<Self::Item> {
         self.items.remove(query)

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -20,6 +20,10 @@ pub trait EventMap<K, V> {
     /// but return its values instead of the one wanted to insert
     fn insert(&mut self, k: K, v: V) -> V;
 
+    fn insert_with<F>(&mut self, k: K, f: F) -> V
+    where
+        F: FnOnce() -> V;
+
     fn remove(&mut self, querry: &K) -> Option<V>;
     fn clear(&mut self);
     fn is_empty(&self) -> bool;
@@ -65,11 +69,19 @@ impl<K: RawEvent, const N: usize> EventMap<K, Arc<LedgerNode<K, SmallMap<K, N>>>
     }
 
     fn insert(&mut self, k: K, v: Self::Item) -> Self::Item {
+        self.insert_with(k, || v)
+    }
+
+    fn insert_with<F>(&mut self, k: K, f: F) -> Self::Item
+    where
+        F: FnOnce() -> Self::Item,
+    {
         match self.items.binary_search_by(|(key, _)| key.cmp(&k)) {
             Ok(idx) => {
                 self.items[idx].1.clone()
             }
             Err(idx) => {
+                let v = f();
                 self.items.insert(idx, (k, v.clone())); // keep sorted
                 v
             }
@@ -115,6 +127,12 @@ impl<K: RawEvent> EventMap<K, Arc<LedgerNode<K, EventHashMap<K>>>> for EventHash
     fn values(&self) -> Self::Values<'_> {
         self.items.values()
     }
+    fn insert_with<F>(&mut self, k: K, f: F) -> Self::Item
+    where
+        F: FnOnce() -> Self::Item,
+    {
+        self.items.entry(k).or_insert_with(f).clone()
+    }
     fn insert(&mut self, k: K, v: Self::Item) -> Self::Item {
         self.items.entry(k).or_insert(v).clone()
     }
@@ -151,6 +169,12 @@ impl<K: RawEvent> EventMap<K, Arc<LedgerNode<K, EventBTreeMap<K>>>> for EventBTr
     }
     fn values(&self) -> Self::Values<'_> {
         self.items.values()
+    }
+    fn insert_with<F>(&mut self, k: K, f: F) -> Self::Item
+    where
+        F: FnOnce() -> Self::Item,
+    {
+        self.items.entry(k).or_insert_with(f).clone()
     }
     fn insert(&mut self, k: K, v: Self::Item) -> Self::Item {
         self.items.entry(k).or_insert(v).clone()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,7 +4,7 @@ pub use crate::mcrt_event;
 pub use crate::src::SrcId;
 pub use crate::uid::Uid;
 
-const MAP_SIZE: usize = 4;
+pub const MAP_SIZE: usize = 4;
 
 use crate::ledger::{
     LedgerTree as GenericLedgerTree,


### PR DESCRIPTION
- Remove `cnt: AtomicU32` and trying to fence the overwrite of an insertion in the map
- `insert` in EventMap will not overwrite the node, returining:
  - existing value if entry exists
  - value written to new entry if key was not found
- `insert_with` is a lazy insert, which evaluate the value as a `FnOnce` only if entry with `key` is vacant